### PR TITLE
Fix segmentation fault when route destination is ENI

### DIFF
--- a/aws/route_table.go
+++ b/aws/route_table.go
@@ -118,6 +118,8 @@ func (t *RouteTable) GetSrcByVip(vip string) (*Ec2Meta, error) {
 		if err != nil {
 			return nil, err
 		}
+	default:
+		return nil, errors.New("Not support to switch from neither instance nor ENI destination")
 	}
 	return &Ec2Meta{Name: name, Id: id}, nil
 }

--- a/aws/route_table.go
+++ b/aws/route_table.go
@@ -97,29 +97,44 @@ func (t *RouteTable) ListPossibleVips() *MaybeVips {
 	return &MaybeVips{t, ids, vips, names}
 }
 
-func (t *RouteTable) GetSrcInstanceByVip(vip string) (*Ec2Meta, error) {
+func (t *RouteTable) GetSrcByVip(vip string) (*Ec2Meta, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeOut)
 	defer cancel()
 
-	id, err := t.getSrcInstanceIdByVip(vip)
+	id, err := t.getSrcByVip(vip)
 	if err != nil {
 		return nil, err
 	}
-	name, err := t.cli.getInstanceNameById(ctx, id)
-	if err != nil {
-		return nil, err
+
+	var name string
+	switch {
+	case strings.HasPrefix(id, "i-"):
+		name, err = t.cli.getInstanceNameById(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+	case strings.HasPrefix(id, "eni-"):
+		name, err = t.cli.getENINameById(ctx, id)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &Ec2Meta{Name: name, Id: id}, nil
 }
 
-func (t *RouteTable) getSrcInstanceIdByVip(vip string) (string, error) {
+func (t *RouteTable) getSrcByVip(vip string) (string, error) {
 	vipCidrBlock := vip
 	if !strings.HasSuffix(vipCidrBlock, "/32") {
 		vipCidrBlock = fmt.Sprintf("%s/32", vipCidrBlock)
 	}
 	for _, route := range t.table.Routes {
-		if *route.DestinationCidrBlock == vipCidrBlock && *route.InstanceId != "" {
-			return *route.InstanceId, nil
+		if *route.DestinationCidrBlock == vipCidrBlock {
+			switch {
+			case route.InstanceId != nil && *route.InstanceId != "":
+				return *route.InstanceId, nil
+			case route.NetworkInterfaceId != nil && *route.NetworkInterfaceId != "":
+				return *route.NetworkInterfaceId, nil
+			}
 		}
 	}
 	return "", errors.New("Given vip is not found")

--- a/command/switch.go
+++ b/command/switch.go
@@ -36,12 +36,12 @@ func CmdSwitch(c *cli.Context) error {
 `
 	routeTableName := routeTable.GetRouteTableName()
 	routeTableId := routeTable.GetRouteTableId()
-	srcInstance, err := routeTable.GetSrcInstanceByVip(vip)
+	src, err := routeTable.GetSrcByVip(vip)
 	if err != nil {
 		return err
 	}
 	ws := strings.Repeat(" ", len(vip))
-	fmt.Fprintf(os.Stdout, promptStr, routeTableName, routeTableId, vip, srcInstance.Name, srcInstance.Id, ws, ws, instanceKey)
+	fmt.Fprintf(os.Stdout, promptStr, routeTableName, routeTableId, vip, src.Name, src.Id, ws, ws, instanceKey)
 	if !force && !prompter.YN("Are you sure?", false) {
 		fmt.Fprintln(os.Stderr, "Switching is canceled")
 		return nil


### PR DESCRIPTION
I found swiro cause segmentation fault when route destination is ENI. And this PR fixes issues and treat ENI destination.

``` sh
$ /usr/local/bin/swiro switch -f -r rtb-xxxxxxxx -v 10.0.0.4 -I example001
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x4d6c03]

goroutine 1 [running]:
panic(0x91e7a0, 0xc4200100a0)
        /usr/local/opt/go/libexec/src/runtime/panic.go:500 +0x1a1
github.com/taku-k/swiro/aws.(*RouteTable).getSrcInstanceIdByVip(0xc4203ba320, 0xc420011bb5, 0xb, 0xcea020, 0xc4201adec0, 0xc4203ba360, 0x4)
        /Users/taku_k/go/src/github.com/taku-k/swiro/aws/route_table.go:121 +0x1a3
github.com/taku-k/swiro/aws.(*RouteTable).GetSrcInstanceByVip(0xc4203ba320, 0xc420011bb5, 0xb, 0x0, 0x0, 0x0)
        /Users/taku_k/go/src/github.com/taku-k/swiro/aws/route_table.go:104 +0xd6
github.com/taku-k/swiro/command.CmdSwitch(0xc42006cdc0, 0x1010100, 0xc42006cdc0)
        /Users/taku_k/go/src/github.com/taku-k/swiro/command/switch.go:39 +0x1bf
github.com/taku-k/swiro/vendor/github.com/urfave/cli.HandleAction(0x8d6dc0, 0xa11108, 0xc42006cdc0, 0xc42004a600, 0x0)
        /Users/taku_k/go/src/github.com/taku-k/swiro/vendor/github.com/urfave/cli/app.go:485 +0xd4
github.com/taku-k/swiro/vendor/github.com/urfave/cli.Command.Run(0x9c9b8b, 0x6, 0x0, 0x0, 0x0, 0x0, 0x0, 0x9dd6fc, 0x29, 0x0, ...)
        /Users/taku_k/go/src/github.com/taku-k/swiro/vendor/github.com/urfave/cli/command.go:193 +0xb96
github.com/taku-k/swiro/vendor/github.com/urfave/cli.(*App).Run(0xc4200e71e0, 0xc42000a090, 0x9, 0x9, 0x0, 0x0)
        /Users/taku_k/go/src/github.com/taku-k/swiro/vendor/github.com/urfave/cli/app.go:250 +0x812
main.main()
        /Users/taku_k/go/src/github.com/taku-k/swiro/main.go:22 +0x142 
```