### PR TITLE
Exclude route have nil with destination cidr block in `list` subcommand

### DIFF
--- a/aws/route_table.go
+++ b/aws/route_table.go
@@ -83,6 +83,10 @@ func (t *RouteTable) ListPossibleVips() *MaybeVips {
 	vips := make([]string, 0, len(t.table.Routes))
 	names := make([]string, 0, len(t.table.Routes))
 	for _, r := range t.table.Routes {
+		// VPC Endpoint route does not have DestinationCidrBlock field and It can not be modified
+		if r.DestinationCidrBlock == nil {
+			continue
+		}
 		if strings.HasSuffix(*r.DestinationCidrBlock, "/32") {
 			if r.InstanceId != nil {
 				ids = append(ids, *r.InstanceId)


### PR DESCRIPTION
VPC endpoint that is created in the route table, its destination is not an IP address. So, `DestinationCidrBlock` becomes nil and `list` subcommand crashes as the following:

```sh
~$ /usr/local/bin/swiro list 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x86bd01]

goroutine 1 [running]:
github.com/taku-k/swiro/aws.(*RouteTable).ListPossibleVips(0xc420322380, 0x0)
        /Users/taku/go/src/github.com/taku-k/swiro/aws/route_table.go:86 +0x241
github.com/taku-k/swiro/command.CmdList(0xc42008ec80, 0x0, 0xc42008ec80)
        /Users/taku/go/src/github.com/taku-k/swiro/command/list.go:14 +0x5d
github.com/taku-k/swiro/vendor/github.com/urfave/cli.HandleAction(0x905400, 0xa1ee08, 0xc42008ec80, 0xc420046500, 0x0)
        /Users/taku/go/src/github.com/taku-k/swiro/vendor/github.com/urfave/cli/app.go:485 +0xd2
github.com/taku-k/swiro/vendor/github.com/urfave/cli.Command.Run(0xa0334e, 0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0xa165a6, 0x30, 0x0, ...)
        /Users/taku/go/src/github.com/taku-k/swiro/vendor/github.com/urfave/cli/command.go:193 +0xa99
github.com/taku-k/swiro/vendor/github.com/urfave/cli.(*App).Run(0xc420104d00, 0xc42000a060, 0x2, 0x2, 0x0, 0x0)
        /Users/taku/go/src/github.com/taku-k/swiro/vendor/github.com/urfave/cli/app.go:250 +0x758
main.main()
        /Users/taku/go/src/github.com/taku-k/swiro/main.go:24 +0x1f7
```